### PR TITLE
Indexed Variable Factories should allow setters

### DIFF
--- a/src/main/java/org/mvel2/integration/impl/IndexedVariableResolverFactory.java
+++ b/src/main/java/org/mvel2/integration/impl/IndexedVariableResolverFactory.java
@@ -58,7 +58,8 @@ public class IndexedVariableResolverFactory extends BaseVariableResolverFactory 
     }
 
     public VariableResolver createIndexedVariable(int index, String name, Object value) {
-        throw new RuntimeException("Error: cannot write to factory");
+        indexedVariableResolvers[index].setValue( value );
+        return indexedVariableResolvers[index];
     }
 
     public VariableResolver getIndexedVariableResolver(int index) {

--- a/src/main/java/org/mvel2/integration/impl/IndexedVariableResolverFactory.java
+++ b/src/main/java/org/mvel2/integration/impl/IndexedVariableResolverFactory.java
@@ -67,12 +67,29 @@ public class IndexedVariableResolverFactory extends BaseVariableResolverFactory 
     }
 
     public VariableResolver createVariable(String name, Object value) {
-        return nextFactory.createVariable(name, value);
+        VariableResolver vr = getResolver( name );
+        if ( vr != null ) {
+            vr.setValue( value );
+            return vr;
+        } else {
+            if (nextFactory == null) nextFactory = new MapVariableResolverFactory(new HashMap());
+            return nextFactory.createVariable(name, value);
+        }
     }
 
     public VariableResolver createVariable(String name, Object value, Class<?> type) {
-        if (nextFactory == null) nextFactory = new MapVariableResolverFactory(new HashMap());
-        return nextFactory.createVariable(name, value, type);
+        VariableResolver vr = getResolver( name );
+        if ( vr != null ) {
+            if ( vr.getType() != null ) {
+                throw new RuntimeException("variable already defined within scope: " + vr.getType() + " " + name);
+            } else {
+                vr.setValue( value );
+                return vr;
+            }
+        } else {
+            if (nextFactory == null) nextFactory = new MapVariableResolverFactory(new HashMap());
+            return nextFactory.createVariable(name, value, type);
+        }
     }
 
     public VariableResolver getVariableResolver(String name) {

--- a/src/test/java/org/mvel2/tests/core/TypesAndInferenceTests.java
+++ b/src/test/java/org/mvel2/tests/core/TypesAndInferenceTests.java
@@ -1431,4 +1431,27 @@ public class TypesAndInferenceTests extends AbstractTest {
 
         assertEquals("Mac", MVEL.executeExpression(stmt, new EchoContext()));
     }
+    
+    public void testForLoopTypeCoercion() {
+        ParserContext pCtx = ParserContext.create();
+        pCtx.setStrictTypeEnforcement( true );
+        pCtx.setStrongTyping( true );
+        pCtx.addInput( "$type", String.class );
+        pCtx.addInput( "l", List.class );
+      
+        Map<String, Object> vars = new HashMap<String, Object>();
+        vars.put(  "$type", "pc!!" );
+        List list = new ArrayList();
+        vars.put(  "l", list );
+        ExecutableStatement stmt = ( ExecutableStatement ) MVEL.compileExpression("for (byte bt:$type.getBytes()) {l.add( bt);}", pCtx);
+        MVEL.executeExpression(stmt, null, vars);
+        
+        byte[] exp = "pc!!".getBytes();
+        byte[] res = new byte[list.size()];
+        for (int i = 0; i < exp.length; i++  ) {
+            assertEquals( exp[i], res[i] );
+        }    
+    }    
+    
+
 }


### PR DESCRIPTION
Currently the factory does not allow creation of an indexed variable. However in Drools we have a use case for this. We want MVEL to be able to assign the value of an "input", we then retrieve that value and use it in an context for execution.
