### PR TITLE
failing tests for java.lang and blocks

### DIFF
--- a/src/main/java/org/mvel2/ast/ForEachNode.java
+++ b/src/main/java/org/mvel2/ast/ForEachNode.java
@@ -18,6 +18,7 @@
 package org.mvel2.ast;
 
 import org.mvel2.CompileException;
+import org.mvel2.DataConversion;
 import org.mvel2.MVEL;
 import org.mvel2.ParserContext;
 import org.mvel2.compiler.ExecutableStatement;
@@ -218,7 +219,7 @@ public class ForEachNode extends BlockNode {
     }
 
     private  void enforceTypeSafety(Class required, Class actual) {
-        if (!required.isAssignableFrom(actual)) {
+        if (!required.isAssignableFrom(actual) && !DataConversion.canConvert(actual, required)) {
             throw new CompileException("type mismatch in foreach: expected: "
                     + required.getName() + "; but found: " + getBaseComponentType(actual), expr, start);
         }

--- a/src/main/java/org/mvel2/integration/impl/IndexedVariableResolverFactory.java
+++ b/src/main/java/org/mvel2/integration/impl/IndexedVariableResolverFactory.java
@@ -28,22 +28,13 @@ import java.util.Set;
 
 @SuppressWarnings({"unchecked"})
 public class IndexedVariableResolverFactory extends BaseVariableResolverFactory {
-    /**
-     * Holds the instance of the variables.
-     */
-
-    private Object[] values;
-
     public IndexedVariableResolverFactory(String[] varNames, Object[] values) {
         this.indexedVariableNames = varNames;
-        this.values = values;
-       // this.nextFactory = new MapVariableResolverFactory();
         this.indexedVariableResolvers = createResolvers(values);
     }
 
     public IndexedVariableResolverFactory(String[] varNames, Object[] values, VariableResolverFactory nextFactory) {
         this.indexedVariableNames = varNames;
-        this.values = values;
         this.nextFactory = new MapVariableResolverFactory();
         this.nextFactory.setNextFactory(nextFactory);
         this.indexedVariableResolvers = createResolvers(values);

--- a/src/main/java/org/mvel2/integration/impl/IndexedVariableResolverFactory.java
+++ b/src/main/java/org/mvel2/integration/impl/IndexedVariableResolverFactory.java
@@ -58,8 +58,7 @@ public class IndexedVariableResolverFactory extends BaseVariableResolverFactory 
     }
 
     public VariableResolver createIndexedVariable(int index, String name, Object value) {
-        indexedVariableResolvers[index].setValue( value );
-        return indexedVariableResolvers[index];
+        throw new RuntimeException("Error: cannot write to factory");
     }
 
     public VariableResolver getIndexedVariableResolver(int index) {

--- a/src/test/java/org/mvel2/tests/core/CoreConfidenceTests.java
+++ b/src/test/java/org/mvel2/tests/core/CoreConfidenceTests.java
@@ -3103,4 +3103,18 @@ public class CoreConfidenceTests extends AbstractTest {
         ParserContext pctx = new ParserContext(pconf);        
         MVEL.compileExpression( s, pctx );      
     }     
+    
+    public void testContextFieldNotFound() {
+        String str = "'stilton'.equals( type );";
+        
+        ParserConfiguration pconf = new ParserConfiguration();
+        
+        ParserContext pctx = new ParserContext(pconf);
+        pctx.addInput( "this", Cheese.class );
+        pctx.setStrictTypeEnforcement( true );
+        pctx.setStrongTyping( true );
+        
+        ExecutableStatement stmt = (ExecutableStatement) MVEL.compileExpression( str, pctx );
+        MVEL.executeExpression(stmt, new Cheese(), new HashMap() );                
+    }    
 }

--- a/src/test/java/org/mvel2/tests/core/CoreConfidenceTests.java
+++ b/src/test/java/org/mvel2/tests/core/CoreConfidenceTests.java
@@ -303,9 +303,6 @@ public class CoreConfidenceTests extends AbstractTest {
     }
 
     public void testTestIntToLong() {
-        //System.out.println( int.class.isAssignableFrom( Integer.class ) );
-        //Number n = new Integer ( 3 )
-
         String s = "1+(long)a";
 
         ParserContext pc = new ParserContext();

--- a/src/test/java/org/mvel2/tests/core/CoreConfidenceTests.java
+++ b/src/test/java/org/mvel2/tests/core/CoreConfidenceTests.java
@@ -3092,4 +3092,18 @@ public class CoreConfidenceTests extends AbstractTest {
         
         MVEL.compileExpression( text, pctx );
     }    
+    
+    public void testJavaLangImport() throws Exception {
+        String s = "Exception e = null;";
+        ParserConfiguration pconf = new ParserConfiguration();
+        ParserContext pctx = new ParserContext(pconf);        
+        MVEL.compileExpression( s, pctx );    
+    }      
+    
+    public void testBlocks() throws Exception {
+        String s = "{java.lang.Exception e = null;}";
+        ParserConfiguration pconf = new ParserConfiguration();
+        ParserContext pctx = new ParserContext(pconf);        
+        MVEL.compileExpression( s, pctx );      
+    }     
 }

--- a/src/test/java/org/mvel2/tests/core/TypesAndInferenceTests.java
+++ b/src/test/java/org/mvel2/tests/core/TypesAndInferenceTests.java
@@ -1447,9 +1447,10 @@ public class TypesAndInferenceTests extends AbstractTest {
         MVEL.executeExpression(stmt, null, vars);
         
         byte[] exp = "pc!!".getBytes();
-        byte[] res = new byte[list.size()];
+      //  byte[] res = new byte[list.size()];
+
         for (int i = 0; i < exp.length; i++  ) {
-            assertEquals( exp[i], res[i] );
+            assertEquals( exp[i], list.get(i));
         }    
     }    
     


### PR DESCRIPTION
Some java.lang.\* classes are not recognised without importing them
blocks don't work for initialised variables.
