### PR TITLE
Fix TypeCheck exception message

### DIFF
--- a/src/main/java/org/mvel2/ast/TypeCast.java
+++ b/src/main/java/org/mvel2/ast/TypeCast.java
@@ -85,7 +85,7 @@ public class TypeCast extends ASTNode {
       return inst;
     }
     else {
-      throw new ClassCastException(inst.getClass().getName() + " cannot be cast to: " + type.getClass().getName());
+      throw new ClassCastException(inst.getClass().getName() + " cannot be cast to: " + type.getName());
     }
   }
 }


### PR DESCRIPTION
Return name of checked type, instead of java.lang.Class
